### PR TITLE
Create sn30pro-chrome-cros.json

### DIFF
--- a/mappings/sn30pro-chrome-cros.json
+++ b/mappings/sn30pro-chrome-cros.json
@@ -1,0 +1,122 @@
+{
+  "axes": {
+    "dpad x": {
+      "index": 6
+    },
+    "dpad y": {
+      "index": 7
+    },
+    "left stick x": {
+      "index": 0
+    },
+    "left stick y": {
+      "index": 1
+    },
+    "right stick x": {
+      "index": 2
+    },
+    "right stick y": {
+      "index": 3
+    },
+    "left trigger": {
+      "buttonAnalog": 8
+    },
+    "right trigger": {
+      "buttonAnalog": 9
+    }
+  },
+  "buttons": {
+    "a": {
+      "index": 1
+    },
+    "b": {
+      "index": 0
+    },
+    "back": {
+      "index": 10
+    },
+    "dpad down": {
+      "axis": 6,
+      "direction": 1
+    },
+    "dpad left": {
+      "axis": 7,
+      "direction": -1
+    },
+    "dpad right": {
+      "axis": 7,
+      "direction": 1
+    },
+    "dpad up": {
+      "axis": 6,
+      "direction": -1
+    },
+    "home": {
+      "index": 2
+    },
+    "left shoulder": {
+      "index": 6
+    },
+    "left stick": {
+      "index": 13
+    },
+    "left stick down": {
+      "axis": 1,
+      "direction": 1
+    },
+    "left stick left": {
+      "axis": 0,
+      "direction": -1
+    },
+    "left stick right": {
+      "axis": 0,
+      "direction": 1
+    },
+    "left stick up": {
+      "axis": 1,
+      "direction": -1
+    },
+    "left trigger": {
+      "index": 8
+    },
+    "right shoulder": {
+      "index": 7
+    },
+    "right stick": {
+      "index": 14
+    },
+    "right stick down": {
+      "axis": 3,
+      "direction": 1
+    },
+    "right stick left": {
+      "axis": 2,
+      "direction": -1
+    },
+    "right stick right": {
+      "axis": 2,
+      "direction": 1
+    },
+    "right stick up": {
+      "axis": 3,
+      "direction": -1
+    },
+    "start": {
+      "index": 11
+    },
+    "x": {
+      "index": 4
+    },
+    "y": {
+      "index": 3
+    }
+  },
+  "name": "8Bitdo SN30 Pro CrOS",
+  "supported": [
+    {
+      "browser": "Chrome",
+      "id": "8Bitdo SN30 Pro (Vendor: 2dc8 Product: 6101)",
+      "os": "CrOS"
+    }
+  ]
+}


### PR DESCRIPTION
Bindings for 8Bitdo SN30 Pro on Chrome OS under the Chrome browser.